### PR TITLE
fix: dead link used in test_get_changelog_url

### DIFF
--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -31,7 +31,7 @@ from dephell_changelogs._finder import get_changelog_url
     ),
     (
         'sqlalchemy',
-        'https://raw.githubusercontent.com/sqlalchemy/sqlalchemy/master/CHANGES',
+        'https://raw.githubusercontent.com/sqlalchemy/sqlalchemy/master/CHANGES.rst',
     ),
     (
         'django-hijack',


### PR DESCRIPTION
One of the links used in the tests are dead, and it broke the tests (which is blocking a package installation in AUR, by cascade)